### PR TITLE
tech(TTB-071): GameControlCounter now uses GameControl component

### DIFF
--- a/client/src/components/Game/GameControlCounter.jsx
+++ b/client/src/components/Game/GameControlCounter.jsx
@@ -2,20 +2,7 @@ import React from 'react';
 import { MdHome, MdReplay, MdShare } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import styled from "styled-components";
-
-const StyledIcon = styled.div`
-  width: 50px;
-  height: 50px;
-
-  @media (max-width: 768px) {
-    width: 45px;
-    height: 45px;
-  }
-  @media (max-width: 320px) {
-    width: 40px;
-    height: 40px;
-  }
-`;
+import GameControl from './GameControl';
 
 const StyledCounter = styled.span`
     position: absolute;
@@ -28,22 +15,23 @@ const StyledCounter = styled.span`
     justify-content: center;
     align-items: center;
     display: inline-flex;
+
+    @media (max-width: 768px) {
+      width: 14px;
+      height: 14px;
+    }
+    @media (max-width: 320px) {
+      width: 12px;
+      height: 12px;
+      font-size: 8px;
+    }
 `;
 
-const icons = {
-  home: MdHome,
-  reset: MdReplay,
-  share: MdShare,
-
-};
-
 function GameControlCounter({iconType, onClick, link, to, count}) {
-  const Icon = icons[iconType];
-  
   const control =
     <>
       <div>
-        <StyledIcon as={Icon} color={"#222"} onClick={onClick}/>
+        <GameControl iconType={iconType} onClick={onClick}/>
         {count !== 0 && <StyledCounter>{count}</StyledCounter>}
       </div>
     </>


### PR DESCRIPTION
GameControlCounter component has been updated to utilise the GameControl component (reason: remove duplicated code & styling).

GameControlCounter styling has also been made more responsive - smaller screens will render a smaller count badge.